### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   },
   "dependencies": {
     "jsdom": "^24.0.0",
-    "node-html-parser": "^6.1.12"
+    "node-html-parser": "^6.1.12",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",

--- a/src/integrations/shared.ts
+++ b/src/integrations/shared.ts
@@ -3,7 +3,7 @@
  */
 
 import type { SeoConfig } from '../types/SeoTypes';
-
+import sanitizeHtml from 'sanitize-html';
 /**
  * Common utility functions for framework integrations
  */
@@ -61,11 +61,10 @@ export function formatApiResponse<T>(
  * Extract content from HTML string
  */
 export function extractTextFromHtml(html: string): string {
-  // Basic HTML tag removal - in production, use a proper HTML parser
-  return html
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  // Use sanitize-html to reliably remove all HTML tags and extract text content
+  return sanitizeHtml(html, {
+    allowedTags: [],
+    allowedAttributes: {},
+    textFilter: (text) => text.replace(/\s+/g, ' ')
+  }).trim();
 }


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/npm-seo/security/code-scanning/1](https://github.com/RumenDamyanov/npm-seo/security/code-scanning/1)

The best fix is to replace the custom regex-based HTML tag removal (especially for `<script>` and `<style>`) with a well-tested, actively maintained HTML sanitization/parsing library, such as `dompurify` (for browsers) or `sanitize-html` (for Node.js/server). Since this is a TypeScript file for shared utility and may run in Node.js, we'll use `sanitize-html` for robustness. This allows us to reliably extract plain text from HTML and completely remove scripts, styles, and other risky content, regardless of malformed or non-standard HTML. 

To implement the fix:

- Install the `sanitize-html` npm package.
- Add an import for `sanitizeHtml` at the top of the file.
- Refactor `extractTextFromHtml` to use `sanitizeHtml` to remove all tags and extract only the text. Use the `allowedTags: []` and `allowedAttributes: {}` options to fully strip HTML, guaranteeing no script/style content remains.
- Remove the faulty regular expressions within `extractTextFromHtml`.

All edits required are in `src/integrations/shared.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
